### PR TITLE
non-cloneable warn fix

### DIFF
--- a/src/main/java/ru/mephi/sno/libs/flow/fetcher/GeneralFetcher.kt
+++ b/src/main/java/ru/mephi/sno/libs/flow/fetcher/GeneralFetcher.kt
@@ -55,7 +55,9 @@ open class GeneralFetcher {
                         }
                     }
 
-                log.warn("Flow contains non-cloneable objects: $nonCloneableObjects. Inject original instead")
+                if (nonCloneableObjects.isNotEmpty()) {
+                    log.warn("Flow contains non-cloneable objects: $nonCloneableObjects. Inject original instead")
+                }
 
                 val result = method.call(this, *params.toTypedArray())
                 result?.let { flowContext.insertObject(result) }


### PR DESCRIPTION
Фикс логов. Раньше логи о инжекте неклонируемых объектов писались даже в том случае если их нет